### PR TITLE
pass SSR context

### DIFF
--- a/lib/react_layout.js
+++ b/lib/react_layout.js
@@ -29,20 +29,22 @@ ReactLayout._getRootNode = function() {
   }
 };
 
-ReactLayout.render = function(layoutClass, regions) {
+ReactLayout.render = function(layoutClass, regions, context) {
   if(Meteor.isClient) {
     return this._renderClient(layoutClass, regions);
   } else {
-    return this._renderServer(layoutClass, regions);
+    return this._renderServer(layoutClass, regions, context || null);
   }
 };
 
-ReactLayout._renderServer = function(layoutClass, regions) {
+ReactLayout._renderServer = function(layoutClass, regions, context) {
   var el = React.createElement(layoutClass, regions);
   var elHtml = React.renderToString(el);
-
   var rootNodeHtml = this._buildRootNode();
   var html = rootNodeHtml.replace('</div>', elHtml + '</div>');
+
+  if(context)
+    return context.setHtml(html);
 
   if(Package['kadira:flow-router-ssr']) {
     var FlowRouter = Package['kadira:flow-router-ssr'].FlowRouter;


### PR DESCRIPTION
This PR concerns this issue on FlowRouter : https://github.com/kadirahq/flow-router/issues/205

When ReactLayout.render is called asynchronousely, the ssr context is not accessible anymore. This is a double PR (I'ma making the same for DocHead). It just add the context as an optionnal parametter of the render and _addToHead functions.

So in the action hook of the route constructor in flow router, you can now do this :

```
action( params, queryParams ) {

    let context;
    if ( Meteor.isServer )
        context = FlowRouter.ssrContext.get();

    Meteor.call( 'getAsyncData', ( err, data ) => {

        DocHead.setTitle( data.title, context );

        DocHead.addMeta( {
            name: 'description',
            content: data.description
        }, context );

        ReactLayout.render( ReactLayouts.MainLayout, {
            content: <ReactView.MyView data={ data } />,
        }, context );

    } );

}
```

There's probably a smarter way, but this one works.
