### PR TITLE
Updated to use ReactDOM in React 0.14

### DIFF
--- a/lib/react_layout.js
+++ b/lib/react_layout.js
@@ -56,7 +56,12 @@ ReactLayout._renderClient = function(layoutClass, regions) {
   this._ready(function() {
     var rootNode = self._getRootNode();
     var el = React.createElement(layoutClass, regions);
-    React.render(el, rootNode);
+
+    if (!!Package['react-runtime'].ReactDOM) {
+      ReactDOM.render(el, rootNode);
+    } else {
+      React.render(el, rootNode);
+    }
   });
 };
 


### PR DESCRIPTION
React 0.14 now has ReactDOM object, and that must be used to render into the DOM.
