### PR TITLE
Updated dependency on React to 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### v1.5.3
+* Updated dependency on React to 0.14.3
+
 ### v1.5.2
 * Remove the hot fix to add correct ReactDOMServer support. react@0.14.1_1 has the fix.
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'kadira:react-layout',
   summary: 'Layout Manager for React with SSR Support',
-  version: '1.5.2',
+  version: '1.5.3',
   git: 'https://github.com/kadirahq/meteor-react-layout.git'
 });
 
@@ -22,12 +22,12 @@ Package.onTest(function(api) {
 });
 
 function configure(api) {
-  api.use('react@0.14.1_1');
+  api.use('react@0.14.3');
   api.use('kadira:flow-router-ssr@3.4.0', ['client', 'server'], {weak: true});
   // We don't browserify, but this version fix a huge build time
   // delay, which exists in the react package.
   // Once, react package comes with the updated version, we can remove this.
   api.use('cosmos:browserify@0.8.3');
-  
+
   api.addFiles('lib/react_layout.js', ['client', 'server']);
 }


### PR DESCRIPTION
There's an open [PR](https://github.com/meteor/react-packages/pull/146) to update React to 0.14.3. This dependency-update is to be ready for when that's merged.
