### PR TITLE
Removed the dependency to React 0.14.

### DIFF
--- a/package.js
+++ b/package.js
@@ -22,7 +22,6 @@ Package.onTest(function(api) {
 });
 
 function configure(api) {
-  api.use('react@0.14.3');
   api.use('kadira:flow-router-ssr@3.4.0', ['client', 'server'], {weak: true});
   // We don't browserify, but this version fix a huge build time
   // delay, which exists in the react package.


### PR DESCRIPTION
Although I've used the react-mounter with Meteor 1.3 and React 15, there is a package (https://github.com/meteor-useraccounts/flow-routing) that still uses this package.

I guess I could try to to refactor that package to also use the react-mounter.
